### PR TITLE
Support Laravel Auto-Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,12 @@
       "Restoore\\Systempay\\": "src/"
     }
   },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Restoore\\Systempay\\SystempayServiceProvider"
+      ]
+    }
+  },
   "minimum-stability": "dev"
 }


### PR DESCRIPTION
For Laravel >=5.5 you can instruct Laravel to auto-discover the service provider automatically, this eliminates much of a headache around installing and consuming the package.

See:
https://medium.com/@taylorotwell/package-auto-discovery-in-laravel-5-5-ea9e3ab20518
https://laravel.com/docs/5.7/packages#package-discovery

![auto-discover](https://user-images.githubusercontent.com/20878658/51800993-ef977a80-222f-11e9-80c4-1476b3d25a1f.png)
