### PR TITLE
Removes "vads_trans_date" from config - Fixes #2

### DIFF
--- a/src/config/systempay.php
+++ b/src/config/systempay.php
@@ -12,7 +12,6 @@ return [
             'vads_payment_config' => 'SINGLE',
             'vads_page_action' => 'PAYMENT',
             'vads_version' => 'V2',
-            'vads_trans_date' => gmdate('YmdHis'),
             'vads_currency' => '978'
         ]
     ],


### PR DESCRIPTION
 Removes "vads_trans_date" from config since it causes problems with config:cache